### PR TITLE
Fix version in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-component-router",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "dependencies": {
     "angular": "^1.5.0"
   },


### PR DESCRIPTION
Running:

```
npm run bower cache clean
npm run bower install bower-angular-component-router --save
```

Results in the following message thrown

```
bower bower-angular-component-router#*     invalid-meta for:/tmp/4e0c67b4d99523433e16d135952ddc27/bower/933f13bb45e69b906b332774d8b08170-5836-FA3b52/bower.json
bower bower-angular-component-router#*     invalid-meta The "main" field has to contain only 1 file per filetype; found multiple .js files: ["./angular_1_router.js","./ng_route_shim.js"]
bower angular-component-router#*               mismatch Version declared in the json (0.2.0) is different than the resolved one (0.2.1)
```

And the dependency not being saved in the bower.json.
